### PR TITLE
fix: replace URI::encode with CGI::escape

### DIFF
--- a/woopra_tracker.rb
+++ b/woopra_tracker.rb
@@ -138,7 +138,7 @@ module WoopraRailsSDK
 			if not is_tracking
 				url = "/track/identify/?"
 				get_params.each do |key, value|
-					url += URI::encode(key) + "=" + URI::encode(value) + "&"
+					url += CGI::escape(key) + "=" + CGI::escape(value) + "&"
 				end
 				url = url[0..-1] + "&ce_app=" + @@SDK_ID
 			else
@@ -155,7 +155,7 @@ module WoopraRailsSDK
 				end
 				url = "/track/ce/?"
 				get_params.each do |key, value|
-					url += URI::encode(key) + "=" + URI::encode(value) + "&"
+					url += CGI::escape(key) + "=" + CGI::escape(value) + "&"
 				end
 				url = url[0..-1] + "&ce_app=" + @@SDK_ID
 			end


### PR DESCRIPTION
Fixes problem where `+` in email addresses being replaced with ` `in Woopra, since the`+`is not escaped by`URI::encode` and being treated as a space.

`CGI::escape` escapes the plus correctly as `%2B`, which is unescaped again as `+` on woopra's server.
